### PR TITLE
feat: Add support for inline object completion

### DIFF
--- a/src/languageservice/jsonSchema.ts
+++ b/src/languageservice/jsonSchema.ts
@@ -45,6 +45,7 @@ export interface JSONSchema {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   enum?: any[];
   format?: string;
+  inlineObject?: boolean;
 
   // schema draft 06
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -24,6 +24,7 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-typ
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Schema_Object } from '../utils/jigx/schema-type';
 import * as path from 'path';
+import { prepareInlineCompletion } from '../services/yamlCompletion';
 
 const localize = nls.loadMessageBundle();
 
@@ -1099,7 +1100,7 @@ function validate(
       for (const propertyName of Object.keys(schema.properties)) {
         propertyProcessed(propertyName);
         const propertySchema = schema.properties[propertyName];
-        const child = seenKeys[propertyName];
+        let child = seenKeys[propertyName];
         if (child) {
           if (isBoolean(propertySchema)) {
             if (!propertySchema) {
@@ -1119,6 +1120,10 @@ function validate(
               validationResult.propertiesValueMatches++;
             }
           } else {
+            if (propertySchema.inlineObject) {
+              const newParams = prepareInlineCompletion(child.value?.toString() || '');
+              child = newParams.node;
+            }
             propertySchema.url = schema.url ?? originalSchema.url;
             const propertyValidationResult = new ValidationResult(isKubernetes);
             validate(child, propertySchema, schema, propertyValidationResult, matchingSchemas, isKubernetes);

--- a/src/languageservice/services/yamlHoverDetail.ts
+++ b/src/languageservice/services/yamlHoverDetail.ts
@@ -134,7 +134,7 @@ export class YamlHoverDetail {
         matchingSchemas.every((s) => {
           if (s.node === node && !s.inverted && s.schema) {
             title = title || s.schema.title;
-            markdownDescription = markdownDescription || s.schema.markdownDescription || toMarkdown(s.schema.description);
+            markdownDescription = s.schema.markdownDescription || toMarkdown(s.schema.description);
             if (s.schema.enum) {
               const idx = s.schema.enum.indexOf(getNodeValue(node));
               if (s.schema.markdownEnumDescriptions) {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1935,6 +1935,102 @@ suite('Auto Completion Tests', () => {
           assert.equal(result.items[0].label, '- (array item) 1');
         });
       });
+      describe('Inline object completion', () => {
+        const inlineObjectSchema = require(path.join(__dirname, './fixtures/testInlineObject.json'));
+        it('simple-null', (done) => {
+          languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+          const content = 'value: ';
+          const completion = parseSetup(content, content.length);
+          completion
+            .then(function (result) {
+              assert.equal(result.items.length, 1);
+              assert.equal(result.items[0].insertText, 'context');
+            })
+            .then(done, done);
+        });
+        it('simple-context.', (done) => {
+          languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+          const content = 'value: context.';
+          const completion = parseSetup(content, content.length);
+          completion
+            .then(function (result) {
+              assert.equal(result.items.length, 2);
+              assert.equal(result.items[0].insertText, 'jig');
+            })
+            .then(done, done);
+        });
+        it('simple-context.da', (done) => {
+          languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+          const content = 'value: context.da';
+          const completion = parseSetup(content, content.length);
+          completion
+            .then(function (result) {
+              assert.equal(result.items.length, 2);
+              assert.equal(result.items[0].insertText, 'jig');
+              assert.equal(result.items[1].insertText, 'data');
+              assert.deepStrictEqual(result.items[1].textEdit.range.start, { line: 0, character: content.lastIndexOf('.') + 1 });
+            })
+            .then(done, done);
+        });
+        it('anyOf[obj|ref]-null', (done) => {
+          languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+          const content = 'value1: ';
+          const completion = parseSetup(content, content.length);
+          completion
+            .then(function (result) {
+              assert.equal(result.items.length, 1);
+              assert.equal(result.items[0].insertText, 'context');
+            })
+            .then(done, done);
+        });
+        it('anyOf[obj|ref]-insideObject', (done) => {
+          languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+          const content = 'value1:\n  ';
+          const completion = parseSetup(content, content.length);
+          completion
+            .then(function (result) {
+              assert.equal(result.items.length, 1);
+              assert.equal(result.items[0].label, 'prop1');
+            })
+            .then(done, done);
+        });
+        it('anyOf[const|ref]-null', (done) => {
+          languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+          const content = 'value2: ';
+          const completion = parseSetup(content, content.length);
+          completion
+            .then(function (result) {
+              assert.equal(result.items.length, 3);
+              assert.equal(result.items[0].insertText, 'const1');
+              assert.equal(result.items[2].insertText, 'context');
+            })
+            .then(done, done);
+        });
+        it('anyOf[const|ref]-context.', (done) => {
+          languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+          const content = 'value2: context.';
+          const completion = parseSetup(content, content.length);
+          completion
+            .then(function (result) {
+              assert.equal(result.items.length, 4);
+              assert.equal(result.items[2].insertText, 'jig');
+            })
+            .then(done, done);
+        });
+        it('anyOf[const|ref]-context.da', (done) => {
+          languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+          const content = 'value2: context.da';
+          const completion = parseSetup(content, content.length);
+          completion
+            .then(function (result) {
+              assert.equal(result.items.length, 4);
+              assert.equal(result.items[2].insertText, 'jig');
+              assert.equal(result.items[3].insertText, 'data');
+              assert.deepStrictEqual(result.items[3].textEdit.range.start, { line: 0, character: content.lastIndexOf('.') + 1 });
+            })
+            .then(done, done);
+        });
+      });
     });
   });
 });

--- a/test/fixtures/testInlineObject.json
+++ b/test/fixtures/testInlineObject.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Expression": {
+      "type": "string",
+      "description": "Expression abcd",
+      "inlineObject": true,
+      "properties": {
+        "context": {
+          "properties": {
+            "jig": {
+              "properties": {}
+            },
+            "data": {
+              "properties": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "value": {
+      "inlineObject": true,
+      "properties": {
+        "context": {
+          "properties": {
+            "jig": {
+              "properties": {}
+            },
+            "data": {
+              "properties": {}
+            }
+          }
+        }
+      }
+    },
+    "value1": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "prop1": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/Expression"
+        }
+      ]
+    },
+    "value2": {
+      "anyOf": [
+        {
+          "type": "string",
+          "const": "const1"
+        },
+        {
+          "type": "string",
+          "const": "const2"
+        },
+        {
+          "$ref": "#/definitions/Expression"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}


### PR DESCRIPTION
Add support for inline object completion

### What does this PR do?
Implemented.
added `inlineObject` parameter into schema definition.
With this parameter completionServis will suggest object in inline dot notation.
Instead of:
```yaml
value:
  context:
    data:
      component1:
        state:
```

it will be:
```
value: context.data.component1.state
```

### What issues does this PR fix or reference?
#8 

### Is it tested? How?
added unit tests