### PR TITLE
feat: escape special chars on completion value

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -151,6 +151,9 @@ export class YamlCompletion {
             }
           }
           if (overwriteRange && overwriteRange.start.line === overwriteRange.end.line) {
+            if (completionItem.kind === CompletionItemKind.Value) {
+              completionItem.insertText = escapeSpecialChars(completionItem.insertText);
+            }
             completionItem.textEdit = TextEdit.replace(overwriteRange, completionItem.insertText);
           }
           completionItem.label = label;
@@ -1335,4 +1338,17 @@ function convertToStringValue(value: string): string {
   }
 
   return value;
+}
+
+/**
+ * if contains special chars (@), text will be into apostrophes
+ */
+function escapeSpecialChars(text: string): string {
+  if (text) {
+    const addQuota = text[0] !== `'` && (text.startsWith('@') || text.startsWith('&'));
+    if (addQuota) {
+      return `'${text}'`;
+    }
+  }
+  return text;
 }

--- a/test/autoCompletionJigx.test.ts
+++ b/test/autoCompletionJigx.test.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai';
+import { CompletionList, Position } from 'vscode-languageserver/node';
+import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import { LanguageService } from '../src/languageservice/yamlLanguageService';
+import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
+import { ServiceSetup } from './utils/serviceSetup';
+import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { createExpectedCompletion } from './utils/verifyError';
+
+describe('Jigx Auto Completion Tests', () => {
+  let languageSettingsSetup: ServiceSetup;
+  let languageService: LanguageService;
+  let languageHandler: LanguageHandlers;
+  let yamlSettings: SettingsState;
+
+  before(() => {
+    languageSettingsSetup = new ServiceSetup().withCompletion().withSchemaFileMatch({
+      uri: 'http://google.com',
+      fileMatch: ['bad-schema.yaml'],
+    });
+    const { languageService: langService, languageHandler: langHandler, yamlSettings: settings } = setupLanguageService(
+      languageSettingsSetup.languageSettings
+    );
+    languageService = langService;
+    languageHandler = langHandler;
+    yamlSettings = settings;
+  });
+
+  function parseSetup(content: string, position: number): Promise<CompletionList> {
+    const testTextDocument = setupSchemaIDTextDocument(content);
+    yamlSettings.documents = new TextDocumentTestManager();
+    (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
+    return languageHandler.completionHandler({
+      position: testTextDocument.positionAt(position),
+      textDocument: testTextDocument,
+    });
+  }
+
+  afterEach(() => {
+    languageService.deleteSchema(SCHEMA_ID);
+    languageService.configure(languageSettingsSetup.languageSettings);
+  });
+
+  it('should insert quotation value if there is special char', async () => {
+    languageService.addSchema(SCHEMA_ID, {
+      type: 'object',
+      properties: {
+        from: {
+          type: 'string',
+          const: '@test',
+        },
+      },
+    });
+    const content = 'from: ';
+    const completion = await parseSetup(content, content.length);
+
+    expect(completion.items.length).equal(1);
+    expect(completion.items[0]).to.deep.equal(
+      createExpectedCompletion('@test', "'@test'", 0, 6, 0, 6, 12, 2, {
+        documentation: undefined,
+      })
+    );
+  });
+});


### PR DESCRIPTION
### What does this PR do?
escape special chars on completion value
```yaml
- componentId: "@jigx/ja-submit-form"
```

### What issues does this PR fix or reference?


### Is it tested? How?
UT
