### PR TITLE
feat: parent completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -799,7 +799,9 @@ export class YamlCompletion {
       if (propertySchema.const && options.includeConstValue) {
         if (!value) {
           value = escapeSpecialChars(propertySchema.const);
-          value = ' ' + this.getInsertTextForGuessedValue(value, '', type);
+          value = this.getInsertTextForGuessedValue(value, '', type);
+          value = removeTab1Symbol(value); // prevent const being selected after snippet insert
+          value = ' ' + value;
         }
         nValueProposals++;
       }
@@ -1457,4 +1459,12 @@ function escapeSpecialChars(text: string): string {
     }
   }
   return text;
+}
+
+/**
+ * simplify `{$1:value}` to `value`
+ */
+function removeTab1Symbol(value: string): string {
+  const result = value.replace(/\$\{1:(.*)\}/, '$1');
+  return result;
 }

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -208,9 +208,6 @@ export class YamlCompletion {
             }
           }
           if (overwriteRange && overwriteRange.start.line === overwriteRange.end.line) {
-            if (completionItem.kind === CompletionItemKind.Value) {
-              completionItem.insertText = escapeSpecialChars(completionItem.insertText);
-            }
             completionItem.textEdit = TextEdit.replace(overwriteRange, completionItem.insertText);
           }
           completionItem.label = label;
@@ -798,8 +795,7 @@ export class YamlCompletion {
 
       if (propertySchema.const && options.includeConstValue) {
         if (!value) {
-          value = escapeSpecialChars(propertySchema.const);
-          value = this.getInsertTextForGuessedValue(value, '', type);
+          value = this.getInsertTextForGuessedValue(propertySchema.const, '', type);
           value = removeTab1Symbol(value); // prevent const being selected after snippet insert
           value = ' ' + value;
         }
@@ -1167,7 +1163,7 @@ export class YamlCompletion {
       collector.add({
         kind: this.getSuggestionKind(schema.type),
         label: this.getLabelForValue(schema.const),
-        insertText: this.getInsertTextForValue(schema.const, separatorAfter, undefined),
+        insertText: this.getInsertTextForValue(schema.const, separatorAfter, schema.type),
         insertTextFormat: InsertTextFormat.Snippet,
         documentation: this.fromMarkup(schema.markdownDescription) || schema.description,
       });
@@ -1446,19 +1442,6 @@ function convertToStringValue(value: string): string {
   }
 
   return value;
-}
-
-/**
- * if value stars with special chars (&*@), text will be put into apostrophes
- */
-function escapeSpecialChars(text: string): string {
-  if (text) {
-    const addQuota = text[0] !== `'` && text.match(/^[&*@]/);
-    if (addQuota) {
-      return `'${text}'`;
-    }
-  }
-  return text;
 }
 
 /**

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -6,7 +6,7 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
   ClientCapabilities,
-  CompletionItem,
+  CompletionItem as CompletionItemBase,
   CompletionItemKind,
   CompletionList,
   InsertTextFormat,
@@ -35,11 +35,18 @@ import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { isInComment, isMapContainsEmptyPair } from '../utils/astUtils';
 import { indexOf } from '../utils/astUtils';
 import { isModeline } from './modelineUtil';
+import { getSchemaTypeName } from '../utils/schemaUtils';
 
 const localize = nls.loadMessageBundle();
 
 const doubleQuotesEscapeRegExp = /[\\]+"/g;
 
+interface CompletionItem extends CompletionItemBase {
+  schemaType?: string;
+  indent?: string;
+  isForParentSuggestion?: boolean;
+  isInlineObject?: boolean;
+}
 interface CompletionsCollector {
   add(suggestion: CompletionItem): void;
   error(message: string): void;
@@ -130,8 +137,58 @@ export class YamlCompletion {
     }
 
     const proposed: { [key: string]: CompletionItem } = {};
+    const existingProposeItem = '__';
     const collector: CompletionsCollector = {
       add: (completionItem: CompletionItem) => {
+        const addSuggestionForParent = function (completionItem: CompletionItem): void {
+          const exists = proposed[completionItem.label]?.label === existingProposeItem;
+          const schemaKey = completionItem.schemaType;
+          const completionKind = CompletionItemKind.Class;
+          let parentCompletion = result.items.find((i) => i.label === schemaKey && i.kind === completionKind);
+
+          if (!parentCompletion) {
+            //don't put to parent suggestion if already in yaml
+            if (exists) {
+              return;
+            }
+            parentCompletion = { ...completionItem };
+            parentCompletion.label = schemaKey;
+            parentCompletion.sortText = '_' + parentCompletion.label; //this extended completion goes first
+            parentCompletion.kind = completionKind;
+            result.items.push(parentCompletion);
+          } else if (!exists) {
+            //modify added props to have unique $x
+            const match = parentCompletion.insertText.match(/\$([0-9]+)|\${[0-9]+:/g);
+            let reindexedStr = completionItem.insertText;
+
+            if (match) {
+              const max$index = match
+                .map((m) => +m.replace(/\${([0-9]+)[:|]/g, '$1').replace('$', ''))
+                .reduce((p, n) => (n > p ? n : p), 0);
+              reindexedStr = completionItem.insertText
+                .replace(/\$([0-9]+)/g, (s, args) => '$' + (+args + max$index))
+                .replace(/\${([0-9]+)[:|]/g, (s, args) => '${' + (+args + max$index) + ':');
+            }
+            parentCompletion.insertText += '\n' + (completionItem.indent || '') + reindexedStr;
+          }
+
+          // remove $x for documentation
+          const mdText = parentCompletion.insertText.replace(/\${[0-9]+[:|](.*)}/g, (s, arg) => arg).replace(/\$([0-9]+)/g, '');
+
+          parentCompletion.documentation = <MarkupContent>{
+            kind: MarkupKind.Markdown,
+            value: [
+              ...(completionItem.documentation ? [completionItem.documentation, '', '----', ''] : []),
+              '```yaml',
+              mdText,
+              '```',
+            ].join('\n'),
+          };
+
+          if (parentCompletion.textEdit) {
+            parentCompletion.textEdit.newText = parentCompletion.insertText;
+          }
+        };
         let label = completionItem.label;
         if (!label) {
           // we receive not valid CompletionItem as `label` is mandatory field, so just ignore it
@@ -142,7 +199,7 @@ export class YamlCompletion {
           label = String(label);
         }
         const existing = proposed[label];
-        if (!existing) {
+        if (!existing || completionItem.isForParentSuggestion) {
           label = label.replace(/[\n]/g, '↵');
           if (label.length > 60) {
             const shortendedLabel = label.substr(0, 57).trim() + '...';
@@ -151,11 +208,19 @@ export class YamlCompletion {
             }
           }
           if (overwriteRange && overwriteRange.start.line === overwriteRange.end.line) {
+            if (completionItem.kind === CompletionItemKind.Value) {
+              completionItem.insertText = escapeSpecialChars(completionItem.insertText);
+            }
             completionItem.textEdit = TextEdit.replace(overwriteRange, completionItem.insertText);
           }
           completionItem.label = label;
-          proposed[label] = completionItem;
-          result.items.push(completionItem);
+          if (completionItem.isForParentSuggestion && completionItem.schemaType) {
+            addSuggestionForParent(completionItem);
+          }
+          if (!existing) {
+            proposed[label] = completionItem;
+            result.items.push(completionItem);
+          }
         }
       },
       error: (message: string) => {
@@ -363,7 +428,7 @@ export class YamlCompletion {
         for (const p of properties) {
           if (!currentProperty || currentProperty !== p) {
             if (isScalar(p.key)) {
-              proposed[p.key.value.toString()] = CompletionItem.create('__');
+              proposed[p.key.value.toString()] = CompletionItemBase.create(existingProposeItem);
             }
           }
         }
@@ -494,7 +559,10 @@ export class YamlCompletion {
                       key,
                       propertySchema,
                       separatorAfter,
-                      identCompensation + this.indentation
+                      identCompensation + this.indentation,
+                      {
+                        includeConstValue: false,
+                      }
                     );
                   }
 
@@ -505,6 +573,27 @@ export class YamlCompletion {
                     insertTextFormat: InsertTextFormat.Snippet,
                     documentation: this.fromMarkup(propertySchema.markdownDescription) || propertySchema.description || '',
                   });
+                  // if the prop is required add it also to parent suggestion
+                  if (schema.schema.required?.includes(key)) {
+                    const schemaType = getSchemaTypeName(schema.schema);
+                    collector.add({
+                      label: key,
+                      insertText: this.getInsertTextForProperty(
+                        key,
+                        propertySchema,
+                        separatorAfter,
+                        identCompensation + this.indentation,
+                        {
+                          includeConstValue: true,
+                        }
+                      ),
+                      insertTextFormat: InsertTextFormat.Snippet,
+                      documentation: this.fromMarkup(propertySchema.markdownDescription) || propertySchema.description || '',
+                      schemaType: schemaType,
+                      indent: identCompensation,
+                      isForParentSuggestion: true,
+                    });
+                  }
                 }
               }
             }
@@ -657,7 +746,10 @@ export class YamlCompletion {
     key: string,
     propertySchema: JSONSchema,
     separatorAfter: string,
-    ident = this.indentation
+    ident = this.indentation,
+    options: {
+      includeConstValue?: boolean;
+    } = {}
   ): string {
     const propertyText = this.getInsertTextForValue(key, '', 'string');
     const resultText = propertyText + ':';
@@ -671,6 +763,8 @@ export class YamlCompletion {
           type = 'object';
         } else if (propertySchema.items) {
           type = 'array';
+        } else if (propertySchema.anyOf) {
+          type = 'anyOf';
         }
       }
       if (Array.isArray(propertySchema.defaultSnippets)) {
@@ -701,6 +795,15 @@ export class YamlCompletion {
         }
         nValueProposals += propertySchema.enum.length;
       }
+
+      if (propertySchema.const && options.includeConstValue) {
+        if (!value) {
+          value = escapeSpecialChars(propertySchema.const);
+          value = ' ' + this.getInsertTextForGuessedValue(value, '', type);
+        }
+        nValueProposals++;
+      }
+
       if (isDefined(propertySchema.default)) {
         if (!value) {
           value = ' ' + this.getInsertTextForGuessedValue(propertySchema.default, '', type);
@@ -741,6 +844,9 @@ export class YamlCompletion {
           case 'null':
             value = ' ${1:null}';
             break;
+          case 'anyOf':
+            value = ' $1';
+            break;
           default:
             return propertyText;
         }
@@ -768,6 +874,9 @@ export class YamlCompletion {
       const propertySchema = schema.properties[key] as JSONSchema;
       let type = Array.isArray(propertySchema.type) ? propertySchema.type[0] : propertySchema.type;
       if (!type) {
+        if (propertySchema.anyOf) {
+          type = 'anyOf';
+        }
         if (propertySchema.properties) {
           type = 'object';
         }
@@ -781,6 +890,7 @@ export class YamlCompletion {
           case 'string':
           case 'number':
           case 'integer':
+          case 'anyOf':
             insertText += `${indent}${key}: $${insertIndex++}\n`;
             break;
           case 'array':
@@ -1302,8 +1412,7 @@ function convertToStringValue(value: string): string {
     return `"${value}"`;
   }
 
-  // eslint-disable-next-line prettier/prettier, no-useless-escape
-  if (value.indexOf('\"') !== -1) {
+  if (value.indexOf('"') !== -1) {
     value = value.replace(doubleQuotesEscapeRegExp, '"');
   }
 
@@ -1335,4 +1444,17 @@ function convertToStringValue(value: string): string {
   }
 
   return value;
+}
+
+/**
+ * if value stars with special chars (&*@), text will be put into apostrophes
+ */
+function escapeSpecialChars(text: string): string {
+  if (text) {
+    const addQuota = text[0] !== `'` && text.match(/^[&*@]/);
+    if (addQuota) {
+      return `'${text}'`;
+    }
+  }
+  return text;
 }

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1572,7 +1572,7 @@ describe('Auto Completion Tests', () => {
 
       expect(completion.items.length).equal(1);
       expect(completion.items[0]).to.deep.equal(
-        createExpectedCompletion('@test', "'@test'", 0, 6, 0, 6, 12, 2, {
+        createExpectedCompletion('@test', '"@test"', 0, 6, 0, 6, 12, 2, {
           documentation: undefined,
         })
       );

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -155,8 +155,7 @@ describe('Auto Completion Tests', () => {
           properties: {
             name: {
               type: 'string',
-              // eslint-disable-next-line prettier/prettier, no-useless-escape
-              default: '\"yaml\"',
+              default: '"yaml"',
             },
           },
         });
@@ -177,8 +176,7 @@ describe('Auto Completion Tests', () => {
           properties: {
             name: {
               type: 'string',
-              // eslint-disable-next-line prettier/prettier, no-useless-escape
-              default: '\"yaml\"',
+              default: '"yaml"',
             },
           },
         });
@@ -1559,6 +1557,26 @@ describe('Auto Completion Tests', () => {
         })
         .then(done, done);
     });
+    it('should insert quotation value if there is special char', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          from: {
+            type: 'string',
+            const: '@test',
+          },
+        },
+      });
+      const content = 'from: ';
+      const completion = await parseSetup(content, content.length);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0]).to.deep.equal(
+        createExpectedCompletion('@test', "'@test'", 0, 6, 0, 6, 12, 2, {
+          documentation: undefined,
+        })
+      );
+    });
   });
 
   describe('Indentation Specific Tests', function () {
@@ -1569,7 +1587,7 @@ describe('Auto Completion Tests', () => {
       const completion = parseSetup(content, content.lastIndexOf('he') + 2);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 1);
+          assert.equal(result.items.length, 2);
           assert.deepEqual(
             result.items[0],
             createExpectedCompletion('helm', 'helm:\n    name: $1', 1, 4, 1, 6, 10, 2, {
@@ -1587,7 +1605,7 @@ describe('Auto Completion Tests', () => {
       const completion = parseSetup(content, content.lastIndexOf('he') + 2);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 1);
+          assert.equal(result.items.length, 2);
           assert.deepEqual(
             result.items[0],
             createExpectedCompletion('helm', 'helm:\n               name: $1', 1, 14, 1, 16, 10, 2, {
@@ -1605,7 +1623,7 @@ describe('Auto Completion Tests', () => {
       const completion = parseSetup(content, content.lastIndexOf('he') + 2);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 1);
+          assert.equal(result.items.length, 2);
           assert.deepEqual(
             result.items[0],
             createExpectedCompletion('helm', 'helm:\n \t               name: $1', 1, 16, 1, 18, 10, 2, {
@@ -2103,7 +2121,7 @@ describe('Auto Completion Tests', () => {
 
       const content = 'kind: 111\n';
       const completion = await parseSetup(content, 3);
-      expect(completion.items).lengthOf(1);
+      expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('kind', 'kind', 0, 0, 0, 4, 10, InsertTextFormat.Snippet, { documentation: '' })
       );
@@ -2122,7 +2140,7 @@ describe('Auto Completion Tests', () => {
 
       const content = 'ki: 111\n';
       const completion = await parseSetup(content, 1);
-      expect(completion.items).lengthOf(1);
+      expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('kind', 'kind', 0, 0, 0, 2, 10, InsertTextFormat.Snippet, { documentation: '' })
       );
@@ -2144,7 +2162,7 @@ describe('Auto Completion Tests', () => {
 
       const content = 'kin';
       const completion = await parseSetup(content, 1);
-      expect(completion.items).lengthOf(1);
+      expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('kind', 'kind: $1', 0, 0, 0, 3, 10, InsertTextFormat.Snippet, {
           documentation: {
@@ -2337,10 +2355,151 @@ describe('Auto Completion Tests', () => {
       languageService.addSchema(SCHEMA_ID, schema);
       const content = 'test_array_anyOf_2objects:\n  - obj';
       const completion = await parseSetup(content, content.length);
-      expect(completion.items.length).is.equal(2);
+      expect(completion.items.length).is.equal(4);
       const obj1 = completion.items.find((it) => it.label === 'obj1');
       expect(obj1).is.not.undefined;
       expect(obj1.textEdit.newText).equal('obj1:\n    ');
+    });
+  });
+
+  describe('Parent Completion', () => {
+    const obj1 = {
+      properties: {
+        type: {
+          const: 'type obj1',
+        },
+        options: {
+          type: 'object',
+          properties: {
+            label: {
+              type: 'string',
+            },
+          },
+          required: ['label'],
+        },
+      },
+      required: ['type', 'options'],
+      type: 'object',
+    };
+    const obj2 = {
+      properties: {
+        type: {
+          const: 'type obj2',
+        },
+        options: {
+          type: 'object',
+          properties: {
+            description: {
+              type: 'string',
+            },
+          },
+          required: ['description'],
+        },
+      },
+      required: ['type', 'options'],
+      type: 'object',
+    };
+    it('Should suggest complete object skeleton', async () => {
+      const schema = {
+        definitions: {
+          obj1,
+          obj2,
+        },
+        anyOf: [
+          {
+            $ref: '#/definitions/obj1',
+          },
+          {
+            $ref: '#/definitions/obj2',
+          },
+        ],
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = '';
+      const result = await parseSetup(content, content.length);
+
+      expect(result.items.length).equal(4);
+      expect(result.items[0]).to.deep.equal(createExpectedCompletion('type', 'type', 0, 0, 0, 0, 10, 2, { documentation: '' }));
+      expect(result.items[1]).to.deep.equal(
+        createExpectedCompletion('obj1', 'type: ${1:type obj1}\noptions:\n  label: $2', 0, 0, 0, 0, 7, 2, {
+          documentation: {
+            kind: 'markdown',
+            value: '```yaml\ntype: type obj1\noptions:\n  label: \n```',
+          },
+          isForParentSuggestion: true,
+          sortText: '_obj1',
+          schemaType: 'obj1',
+          indent: '',
+        })
+      );
+      expect(result.items[2]).to.deep.equal(
+        createExpectedCompletion('options', 'options:\n  label: $1', 0, 0, 0, 0, 10, 2, { documentation: '' })
+      );
+      expect(result.items[3]).to.deep.equal(
+        createExpectedCompletion('obj2', 'type: ${1:type obj2}\noptions:\n  description: $2', 0, 0, 0, 0, 7, 2, {
+          documentation: {
+            kind: 'markdown',
+            value: '```yaml\ntype: type obj2\noptions:\n  description: \n```',
+          },
+          isForParentSuggestion: true,
+          sortText: '_obj2',
+          schemaType: 'obj2',
+          indent: '',
+        })
+      );
+    });
+
+    it.only('Should suggest complete object skeleton - array', async () => {
+      const schema = {
+        definitions: {
+          obj1,
+          obj2,
+        },
+        items: {
+          anyOf: [
+            {
+              $ref: '#/definitions/obj1',
+            },
+            {
+              $ref: '#/definitions/obj2',
+            },
+          ],
+        },
+        type: 'array',
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = '- ';
+      const result = await parseSetup(content, content.length);
+
+      expect(result.items.length).equal(4);
+      expect(result.items[0]).to.deep.equal(createExpectedCompletion('type', 'type', 0, 2, 0, 2, 10, 2, { documentation: '' }));
+      expect(result.items[1]).to.deep.equal(
+        createExpectedCompletion('obj1', 'type: ${1:type obj1}\n  options:\n    label: $2', 0, 2, 0, 2, 7, 2, {
+          documentation: {
+            kind: 'markdown',
+            value: '```yaml\ntype: type obj1\n  options:\n    label: \n```',
+          },
+          isForParentSuggestion: true,
+          sortText: '_obj1',
+          schemaType: 'obj1',
+          indent: '  ',
+        })
+      );
+      expect(result.items[2]).to.deep.equal(
+        createExpectedCompletion('options', 'options:\n    label: $1', 0, 2, 0, 2, 10, 2, { documentation: '' })
+      );
+      expect(result.items[3]).to.deep.equal(
+        createExpectedCompletion('obj2', 'type: ${1:type obj2}\n  options:\n    description: $2', 0, 2, 0, 2, 7, 2, {
+          documentation: {
+            kind: 'markdown',
+            value: '```yaml\ntype: type obj2\n  options:\n    description: \n```',
+          },
+          isForParentSuggestion: true,
+          sortText: '_obj2',
+          schemaType: 'obj2',
+          indent: '  ',
+        })
+      );
     });
   });
 });

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2421,7 +2421,7 @@ describe('Auto Completion Tests', () => {
       expect(result.items.length).equal(4);
       expect(result.items[0]).to.deep.equal(createExpectedCompletion('type', 'type', 0, 0, 0, 0, 10, 2, { documentation: '' }));
       expect(result.items[1]).to.deep.equal(
-        createExpectedCompletion('obj1', 'type: ${1:type obj1}\noptions:\n  label: $2', 0, 0, 0, 0, 7, 2, {
+        createExpectedCompletion('obj1', 'type: type obj1\noptions:\n  label: $1', 0, 0, 0, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
             value: '```yaml\ntype: type obj1\noptions:\n  label: \n```',
@@ -2436,7 +2436,7 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('options', 'options:\n  label: $1', 0, 0, 0, 0, 10, 2, { documentation: '' })
       );
       expect(result.items[3]).to.deep.equal(
-        createExpectedCompletion('obj2', 'type: ${1:type obj2}\noptions:\n  description: $2', 0, 0, 0, 0, 7, 2, {
+        createExpectedCompletion('obj2', 'type: type obj2\noptions:\n  description: $1', 0, 0, 0, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
             value: '```yaml\ntype: type obj2\noptions:\n  description: \n```',
@@ -2449,7 +2449,7 @@ describe('Auto Completion Tests', () => {
       );
     });
 
-    it.only('Should suggest complete object skeleton - array', async () => {
+    it('Should suggest complete object skeleton - array', async () => {
       const schema = {
         definitions: {
           obj1,
@@ -2474,7 +2474,7 @@ describe('Auto Completion Tests', () => {
       expect(result.items.length).equal(4);
       expect(result.items[0]).to.deep.equal(createExpectedCompletion('type', 'type', 0, 2, 0, 2, 10, 2, { documentation: '' }));
       expect(result.items[1]).to.deep.equal(
-        createExpectedCompletion('obj1', 'type: ${1:type obj1}\n  options:\n    label: $2', 0, 2, 0, 2, 7, 2, {
+        createExpectedCompletion('obj1', 'type: type obj1\n  options:\n    label: $1', 0, 2, 0, 2, 7, 2, {
           documentation: {
             kind: 'markdown',
             value: '```yaml\ntype: type obj1\n  options:\n    label: \n```',
@@ -2489,7 +2489,7 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('options', 'options:\n    label: $1', 0, 2, 0, 2, 10, 2, { documentation: '' })
       );
       expect(result.items[3]).to.deep.equal(
-        createExpectedCompletion('obj2', 'type: ${1:type obj2}\n  options:\n    description: $2', 0, 2, 0, 2, 7, 2, {
+        createExpectedCompletion('obj2', 'type: type obj2\n  options:\n    description: $1', 0, 2, 0, 2, 7, 2, {
           documentation: {
             kind: 'markdown',
             value: '```yaml\ntype: type obj2\n  options:\n    description: \n```',

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1581,7 +1581,30 @@ describe('Auto Completion Tests', () => {
         })
         .then(done, done);
     });
-    it('should insert quotation value if there is special char', async () => {
+    it('Autocomplete should suggest prop with const value', (done) => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          fruit: {
+            const: 'Apple',
+          },
+        },
+      });
+      const content = '';
+      const completion = parseSetup(content, 0);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 1);
+          assert.deepEqual(
+            result.items[0],
+            createExpectedCompletion('fruit', 'fruit: Apple', 0, 0, 0, 0, 10, 2, {
+              documentation: '',
+            })
+          );
+        })
+        .then(done, done);
+    });
+    it('Should insert quotation value if there is special char', async () => {
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -2407,7 +2430,7 @@ describe('Auto Completion Tests', () => {
     const obj1 = {
       properties: {
         type: {
-          const: 'type obj1',
+          const: 'typeObj1',
         },
         options: {
           type: 'object',
@@ -2425,7 +2448,7 @@ describe('Auto Completion Tests', () => {
     const obj2 = {
       properties: {
         type: {
-          const: 'type obj2',
+          const: 'typeObj2',
         },
         options: {
           type: 'object',
@@ -2442,10 +2465,7 @@ describe('Auto Completion Tests', () => {
     };
     it('Should suggest complete object skeleton', async () => {
       const schema = {
-        definitions: {
-          obj1,
-          obj2,
-        },
+        definitions: { obj1, obj2 },
         anyOf: [
           {
             $ref: '#/definitions/obj1',
@@ -2460,42 +2480,35 @@ describe('Auto Completion Tests', () => {
       const result = await parseSetup(content, content.length);
 
       expect(result.items.length).equal(4);
-      expect(result.items[0]).to.deep.equal(createExpectedCompletion('type', 'type', 0, 0, 0, 0, 10, 2, { documentation: '' }));
+      expect(result.items[0]).to.deep.equal(
+        createExpectedCompletion('type', 'type: typeObj1', 0, 0, 0, 0, 10, 2, { documentation: '' })
+      );
       expect(result.items[1]).to.deep.equal(
-        createExpectedCompletion('obj1', 'type: type obj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
+        createExpectedCompletion('obj1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
-            value: '```yaml\ntype: type obj1\noptions:\n  label: \n```',
+            value: '```yaml\ntype: typeObj1\noptions:\n  label: \n```',
           },
-          isForParentSuggestion: true,
           sortText: '_obj1',
-          schemaType: 'obj1',
-          indent: '',
         })
       );
       expect(result.items[2]).to.deep.equal(
         createExpectedCompletion('options', 'options:\n  label: ', 0, 0, 0, 0, 10, 2, { documentation: '' })
       );
       expect(result.items[3]).to.deep.equal(
-        createExpectedCompletion('obj2', 'type: type obj2\noptions:\n  description: ', 0, 0, 0, 0, 7, 2, {
+        createExpectedCompletion('obj2', 'type: typeObj2\noptions:\n  description: ', 0, 0, 0, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
-            value: '```yaml\ntype: type obj2\noptions:\n  description: \n```',
+            value: '```yaml\ntype: typeObj2\noptions:\n  description: \n```',
           },
-          isForParentSuggestion: true,
           sortText: '_obj2',
-          schemaType: 'obj2',
-          indent: '',
         })
       );
     });
 
     it('Should suggest complete object skeleton - array', async () => {
       const schema = {
-        definitions: {
-          obj1,
-          obj2,
-        },
+        definitions: { obj1, obj2 },
         items: {
           anyOf: [
             {
@@ -2513,32 +2526,109 @@ describe('Auto Completion Tests', () => {
       const result = await parseSetup(content, content.length);
 
       expect(result.items.length).equal(4);
-      expect(result.items[0]).to.deep.equal(createExpectedCompletion('type', 'type', 0, 2, 0, 2, 10, 2, { documentation: '' }));
+      expect(result.items[0]).to.deep.equal(
+        createExpectedCompletion('type', 'type: typeObj1', 0, 2, 0, 2, 10, 2, { documentation: '' })
+      );
       expect(result.items[1]).to.deep.equal(
-        createExpectedCompletion('obj1', 'type: type obj1\n  options:\n    label: ', 0, 2, 0, 2, 7, 2, {
+        createExpectedCompletion('obj1', 'type: typeObj1\n  options:\n    label: ', 0, 2, 0, 2, 7, 2, {
           documentation: {
             kind: 'markdown',
-            value: '```yaml\ntype: type obj1\n  options:\n    label: \n```',
+            value: '```yaml\n  type: typeObj1\n  options:\n    label: \n```',
           },
-          isForParentSuggestion: true,
           sortText: '_obj1',
-          schemaType: 'obj1',
-          indent: '  ',
         })
       );
       expect(result.items[2]).to.deep.equal(
         createExpectedCompletion('options', 'options:\n    label: ', 0, 2, 0, 2, 10, 2, { documentation: '' })
       );
       expect(result.items[3]).to.deep.equal(
-        createExpectedCompletion('obj2', 'type: type obj2\n  options:\n    description: ', 0, 2, 0, 2, 7, 2, {
+        createExpectedCompletion('obj2', 'type: typeObj2\n  options:\n    description: ', 0, 2, 0, 2, 7, 2, {
           documentation: {
             kind: 'markdown',
-            value: '```yaml\ntype: type obj2\n  options:\n    description: \n```',
+            value: '```yaml\n  type: typeObj2\n  options:\n    description: \n```',
           },
-          isForParentSuggestion: true,
           sortText: '_obj2',
-          schemaType: 'obj2',
-          indent: '  ',
+        })
+      );
+    });
+    it('Should agregate suggested text without duplicities in insertText', async () => {
+      const schema = {
+        definitions: { obj1, obj2 },
+        anyOf: [
+          {
+            $ref: '#/definitions/obj1',
+          },
+          {
+            $ref: '#/definitions/obj1',
+          },
+        ],
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = '';
+      const result = await parseSetup(content, content.length);
+
+      expect(result.items.length).equal(3);
+      expect(result.items[1]).to.deep.equal(
+        createExpectedCompletion('obj1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
+          documentation: {
+            kind: 'markdown',
+            value: '```yaml\ntype: typeObj1\noptions:\n  label: \n```',
+          },
+          sortText: '_obj1',
+        })
+      );
+    });
+    it('Should suggest rest of the parent object', async () => {
+      const schema = {
+        definitions: { obj1 },
+        $ref: '#/definitions/obj1',
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'type: typeObj1\n';
+      const result = await parseSetup(content, content.length);
+
+      expect(result.items.length).equal(2);
+      expect(result.items[1]).to.deep.equal(
+        createExpectedCompletion('obj1', 'options:\n  label: ', 1, 0, 1, 0, 7, 2, {
+          documentation: {
+            kind: 'markdown',
+            value: '```yaml\noptions:\n  label: \n```',
+          },
+          sortText: '_obj1',
+        })
+      );
+    });
+    it('Should reindex $x', async () => {
+      const schema = {
+        properties: {
+          options: {
+            type: 'object',
+            properties: {
+              label: {
+                type: 'string',
+              },
+            },
+            required: ['label'],
+          },
+          prop1: {
+            type: 'string',
+          },
+        },
+        required: ['type', 'options', 'prop1'],
+        type: 'object',
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = '';
+      const result = await parseSetup(content, content.length);
+
+      expect(result.items.length).equal(3);
+      expect(result.items[1]).to.deep.equal(
+        createExpectedCompletion('object', 'options:\n  label: $1\nprop1: $2', 0, 0, 0, 0, 7, 2, {
+          documentation: {
+            kind: 'markdown',
+            value: '```yaml\noptions:\n  label: \nprop1: \n```',
+          },
+          sortText: '_object',
         })
       );
     });


### PR DESCRIPTION
### What does this PR do?
Add the possibility to suggest the whole object structure. So the user doesn't have to add required properties one by one.
It also works with incomplete objects.

Added also feature that adds const value instead of $1. So instead of `prop: {$1:value}` is used prop: value. (beginning of the second video)

Display two possibilities (anyOf) of complex objects and insert the whole structure of the required props of the object. 

https://user-images.githubusercontent.com/38421337/147861510-b2aa75ea-b583-4fa8-8b07-8f213cddd7b2.mov

Suggest the rest of the 'parent' object (missing required props).

https://user-images.githubusercontent.com/38421337/147861490-bd2032eb-64e5-48c9-9a6f-02abeda0723f.mov

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
few unit tests
