### PR TITLE
feat: remove `if` schema from possible matchingSchemas

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -823,8 +823,9 @@ function validate(
       const subMatchingSchemas = matchingSchemas.newSub();
 
       validate(node, subSchema, originalSchema, subValidationResult, subMatchingSchemas, options);
-      matchingSchemas.merge(subMatchingSchemas);
-
+      // jigx custom: don't want to put `if schema` into regular valid schemas
+      // matchingSchemas.merge(subMatchingSchemas);
+      // end
       if (!subValidationResult.hasProblems()) {
         if (thenSchema) {
           testBranch(thenSchema, originalSchema);

--- a/test/autoCompletionExtend.test.ts
+++ b/test/autoCompletionExtend.test.ts
@@ -354,4 +354,24 @@ describe('Auto Completion Tests Extended', () => {
     //   expect(result.items.length).to.be.equal(0);
     // });
   });
+
+  describe('if/then/else completion', () => {
+    it('should not suggest prop from if statement', async () => {
+      const schema = {
+        id: 'test://schemas/main',
+        if: {
+          properties: {
+            foo: {
+              const: 'bar',
+            },
+          },
+        },
+        then: {},
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = '';
+      const completion = await parseSetup(content, content.length);
+      assert.equal(completion.items.length, 0);
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
if schema block is taken as regular schema.
Doesn't make much sense and complicated another functionality.
Example: 
 - `if` schema is added as valid schema
 - then in completion configuration from `if` is put together with others possible schemas
 - main problem is then in parentCompletion where is not possible to detect that schemas is from `if` condition schema


### Is it tested? How?
add simple UT