### PR TITLE
fix ctx array completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -113,7 +113,10 @@ export class YamlCompletion {
       this.indentation = this.configuredIndentation;
     }
 
-    if (inlineSymbol && lineContent.match(new RegExp(`:\\s*${inlineSymbol}\\..*`))) {
+    // lines examples:
+    // someProp: =@ctx
+    //   - =@ctx
+    if (inlineSymbol && lineContent.match(new RegExp(`[:-]\\s*${inlineSymbol}\\..*`))) {
       result = await this.doInlineCompletion(document, position, isKubernetes, offset, lineContent);
       // const secs = (Date.now() - startTime) / 1000;
       // console.log(
@@ -221,7 +224,11 @@ export class YamlCompletion {
     lineContent: string
   ): Promise<CompletionList> {
     const inlineSymbolPosition = lineContent.indexOf(inlineSymbol);
-    const lineIndent = lineContent.match(/\s*/)[0];
+    let lineIndent = lineContent.match(/\s*/)[0];
+    const isArray = lineContent[lineIndent.length];
+    if (isArray) {
+      lineIndent += this.indentation;
+    }
     const originalText = lineContent.slice(inlineSymbolPosition);
     const props = originalText.split('.');
     let newText = props.reduce((reducer, prop, index) => {

--- a/src/languageservice/utils/jigx/schema2md.ts
+++ b/src/languageservice/utils/jigx/schema2md.ts
@@ -11,7 +11,6 @@ import {
   getDescription,
   getIndent,
   replace,
-  replaceSpecialCharsInDescription,
   tableColumnSeparator,
   toCodeSingleLine,
   toTsBlock,

--- a/test/autoCompletionExtend.test.ts
+++ b/test/autoCompletionExtend.test.ts
@@ -164,6 +164,53 @@ describe('Auto Completion Tests Extended', () => {
         })
         .then(done, done);
     });
+
+    describe('Array', () => {
+      it('array of object null', (done) => {
+        languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+        const content = 'arrayObjExpr:\n  - data: ';
+        const completion = parseSetup(content, content.length);
+        completion
+          .then(function (result) {
+            assert.equal(result.items.length, 1);
+            assert.equal(result.items[0].insertText, '=@ctx');
+          })
+          .then(done, done);
+      });
+      it('array of expr null', (done) => {
+        languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+        const content = 'arraySimpleExpr:\n  - ';
+        const completion = parseSetup(content, content.length);
+        completion
+          .then(function (result) {
+            assert.equal(result.items.length, 1);
+            assert.equal(result.items[0].insertText, '=@ctx');
+          })
+          .then(done, done);
+      });
+      it('array of object ctx.', (done) => {
+        languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+        const content = 'arrayObjExpr:\n  - data: =@ctx.';
+        const completion = parseSetup(content, content.length);
+        completion
+          .then(function (result) {
+            assert.equal(result.items.length, 2);
+            assert.equal(result.items[0].insertText, 'user');
+          })
+          .then(done, done);
+      });
+      it('array of expr ctx.', (done) => {
+        languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+        const content = 'arraySimpleExpr:\n  - =@ctx.';
+        const completion = parseSetup(content, content.length);
+        completion
+          .then(function (result) {
+            assert.equal(result.items.length, 2);
+            assert.equal(result.items[0].insertText, 'user');
+          })
+          .then(done, done);
+      });
+    });
   });
   describe('Complex completion', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/test/fixtures/testInlineObject.json
+++ b/test/fixtures/testInlineObject.json
@@ -28,10 +28,14 @@
               "type": "string"
             }
           },
-          "required": ["propI"]
+          "required": [
+            "propI"
+          ]
         }
       },
-      "required": ["objA"],
+      "required": [
+        "objA"
+      ],
       "type": "object",
       "description": "description of obj1"
     }
@@ -129,6 +133,48 @@
           }
         }
       }
+    },
+    "arraySimpleExpr": {
+      "type": "array",
+      "items": [
+        {
+          "properties": {
+            "=@ctx": {
+              "properties": {
+                "user": {
+                  "properties": {}
+                },
+                "data": {
+                  "properties": {}
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "arrayObjExpr": {
+      "type": "array",
+      "items": [
+        {
+          "properties": {
+            "data": {
+              "properties": {
+                "=@ctx": {
+                  "properties": {
+                    "user": {
+                      "properties": {}
+                    },
+                    "data": {
+                      "properties": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
### What does this PR do?
- [x] ctx expression as an property inside array object
probelm is probably array symbol '-'
 
```yaml
  - value: =@ctx.  #doesn't work
    title: =@ctx. # works ok
```

- [x] expression as a item of the array
not sure if we have this pattern in yaml
```yaml
array:
  - =@ctx....
  - =@ctx....
```

### What issues does this PR fix or reference?
#b:261

### Is it tested? How?
UT