### PR TITLE
feat: ctx in expression string

### DIFF
--- a/src/languageserver/handlers/notificationHandlers.ts
+++ b/src/languageserver/handlers/notificationHandlers.ts
@@ -45,7 +45,8 @@ export class NotificationHandlers {
    * Update the associations in the server
    */
   private schemaAssociationNotificationHandler(associations: Record<string, string[]> | SchemaConfiguration[]): void {
-    console.trace('schemaAssociationsHandler : ' + JSON.stringify(associations));
+    // jigx custom: useless err log for us
+    // console.trace('schemaAssociationsHandler : ' + JSON.stringify(associations));
     this.yamlSettings.schemaAssociations = associations;
     this.yamlSettings.specificValidatorPaths = [];
     this.settingsHandler.pullConfiguration().catch((error) => console.log(error));

--- a/test/fixtures/testInlineObject.json
+++ b/test/fixtures/testInlineObject.json
@@ -42,18 +42,7 @@
   },
   "properties": {
     "value": {
-      "properties": {
-        "=@ctx": {
-          "properties": {
-            "user": {
-              "properties": {}
-            },
-            "data": {
-              "properties": {}
-            }
-          }
-        }
-      }
+      "$ref": "#/definitions/Expression"
     },
     "value1": {
       "anyOf": [
@@ -138,18 +127,7 @@
       "type": "array",
       "items": [
         {
-          "properties": {
-            "=@ctx": {
-              "properties": {
-                "user": {
-                  "properties": {}
-                },
-                "data": {
-                  "properties": {}
-                }
-              }
-            }
-          }
+          "$ref": "#/definitions/Expression"
         }
       ]
     },
@@ -159,18 +137,7 @@
         {
           "properties": {
             "data": {
-              "properties": {
-                "=@ctx": {
-                  "properties": {
-                    "user": {
-                      "properties": {}
-                    },
-                    "data": {
-                      "properties": {}
-                    }
-                  }
-                }
-              }
+              "$ref": "#/definitions/Expression"
             }
           }
         }


### PR DESCRIPTION
### What does this PR do?
Refactor the inline ctx expression codecompletion
Add possibility to autocomplete ctx inside jsonata strings
examples:
```
="hello" & @ctx.user.
=@ctx.jig.state.input.value + 1
=@ctx.whatever + @ctx.user.na
=@ctx.data.petrs[0].test
```
see more in https://github.com/jigx-com/jigx-builder/issues/319#issuecomment-1128829265
or in unittests

The previous implementation was to modify ctx expression in the whole yaml
  - unnecessary complicated to modify existing yaml, count the indent, check the array symbol
Current implementation evaluates the expression in a separate file 'expression'
 - just create simple file
```yaml
expression:
  =@ctx:
    data:
```
with schema referencing to globals-shared#definitions/Expression (client/builder side)


### What issues does this PR fix or reference?


### Is it tested? How?
add few UTs
